### PR TITLE
update out_proj layer of DPMultiheadAttention

### DIFF
--- a/torchdp/layers/dp_multihead_attention.py
+++ b/torchdp/layers/dp_multihead_attention.py
@@ -84,7 +84,9 @@ class DPMultiheadAttention(nn.Module):
         self.klinear = nn.Linear(self.kdim, embed_dim, bias=bias)
         self.vlinear = nn.Linear(self.vdim, embed_dim, bias=bias)
 
-        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        # torch.nn.MultiHeadAttention out_proj is _LinearWithBias
+        # explicilty setting bias=True for consistent mimicry
+        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=True)
 
         self.add_bias_kv = add_bias_kv
         if self.add_bias_kv:


### PR DESCRIPTION
Summary:
`torch.nn.MultiheadAttention`'s out_proj layer has `bias` set to `True` always after the following commit:
https://github.com/pytorch/pytorch/commit/eace0533985641d9c2f36e43e3de694aca886bd9

This commit updates `DPMultiheadAttention` to follow along.

Differential Revision: D22032020

